### PR TITLE
Fix reserved keyword issue

### DIFF
--- a/lib/pithy.js
+++ b/lib/pithy.js
@@ -131,7 +131,7 @@
             attrs.id = ids.join(' ');
         }
         if (classes.length) {
-            attrs.class = classes.join(' ');
+            attrs['class'] = classes.join(' ');
         }
         return attrs;
     };


### PR DESCRIPTION
`class` is a reserved keyword. Noticed it when trying to compile with Google's closure compiler.

https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Reserved_Words
