### PR TITLE
removing unnecessary `Object#toString.call`

### DIFF
--- a/lib/pithy.js
+++ b/lib/pithy.js
@@ -56,7 +56,7 @@
     };
 
     function isString(x) {
-        return toString.call(x) == '[object String]';
+        return typeof x === 'string';
     }
 
     var isArray = Array.isArray || function (x) {


### PR DESCRIPTION
replacing `Object#toString.call` with `typeof` for checking strings, as `typeof` works as expected

btw, i like the idea; `pithy` is very cool
